### PR TITLE
Add redis caching

### DIFF
--- a/demo/demo_website.py
+++ b/demo/demo_website.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from flask import Flask
 from flask import render_template
 
-from redis_cache import redis, cache
+from redis_cache import redis, cache_variation_1, cache_variation_2
 
 client = NasaSyncClient(token="DEMO_KEY")
 app = Flask(__name__)
@@ -12,7 +12,7 @@ app = Flask(__name__)
 REDIS_EXPIRE_TIME_IN_SECONDS = 3600
 
 @app.route("/")
-@cache("apod")
+@cache_variation_1("apod")
 def apod(cache, key):
     if cache is None:
         apod = client.get_astronomy_picture()
@@ -21,3 +21,8 @@ def apod(cache, key):
         apod = cache
     return render_template("test.html", apod=apod, date=datetime.strftime(apod.date, "%Y-%m-%d"))
 
+@app.route("/caching-2")
+@cache_variation_2
+def apod_cache_2():
+    apod = client.get_astronomy_picture()
+    return render_template("test.html", apod=apod, date=datetime.strftime(apod.date, "%Y-%m-%d"))

--- a/demo/demo_website.py
+++ b/demo/demo_website.py
@@ -4,11 +4,20 @@ from datetime import datetime
 from flask import Flask
 from flask import render_template
 
+from redis_cache import redis, cache
+
 client = NasaSyncClient(token="DEMO_KEY")
 app = Flask(__name__)
 
+REDIS_EXPIRE_TIME_IN_SECONDS = 3600
+
 @app.route("/")
-def apod():
-    apod = client.get_astronomy_picture()
+@cache("apod")
+def apod(cache, key):
+    if cache is None:
+        apod = client.get_astronomy_picture()
+        redis.set(name=key, value=apod, ex=REDIS_EXPIRE_TIME_IN_SECONDS)
+    else:
+        apod = cache
     return render_template("test.html", apod=apod, date=datetime.strftime(apod.date, "%Y-%m-%d"))
 

--- a/demo/redis_cache.py
+++ b/demo/redis_cache.py
@@ -4,8 +4,9 @@ from inspect import getfullargspec
 
 # change redis to redis host
 redis = Redis(host="redis", port=6379)
+TTL = 3600 # in seconds
 
-def cache(key: str):
+def cache_variation_1(key: str):
     """
     Redis cache decorator that optionally injects two arguments into the wrapped function.
 
@@ -24,3 +25,19 @@ def cache(key: str):
             return func(*args, **kwargs)
         return wrapper
     return decorator
+
+
+def cache_variation_2(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        key = '-'.join([func.__name__] + list(args))
+        cache = redis.get(key)
+
+        if cache is None:
+            value = func(*args, **kwargs)
+            redis.set(name=key, value=value, ex=TTL)
+        else:
+            value = cache
+        
+        return value
+    return wrapper

--- a/demo/redis_cache.py
+++ b/demo/redis_cache.py
@@ -1,0 +1,26 @@
+from redis import Redis
+from functools import wraps
+from inspect import getfullargspec
+
+# change redis to redis host
+redis = Redis(host="redis", port=6379)
+
+def cache(key: str):
+    """
+    Redis cache decorator that optionally injects two arguments into the wrapped function.
+
+    Optionally injects "cache" and "key" keyword arguments. Where cache is the cached
+    value if present.
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            cache = redis.get(key)
+            argspec = getfullargspec(func).args
+            if "key" in argspec:    
+                kwargs["key"] = key
+            if "cache" in argspec:
+                kwargs["cache"] = cache
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator


### PR DESCRIPTION
Added two variations of caching decorator.
One with a key argument and optional argument injection, only retrieves cache.
Second without the need for an argument and that retrieves cache returning it and does the caching if necessary.
Also modified ``demo_website.py`` to use both decorators for comparing purposes.